### PR TITLE
Add rangeConstraint prop

### DIFF
--- a/Calendar.js
+++ b/Calendar.js
@@ -23,6 +23,7 @@ export default class Calendar extends Component {
   static propTypes = {
     i18n: PropTypes.string,
     format: PropTypes.string,
+    rangeConstraint: PropTypes.string,
     customI18n: PropTypes.object,
     color: PropTypes.object,
     minDate: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
@@ -31,6 +32,7 @@ export default class Calendar extends Component {
   static defaultProps = {
     format: 'YYYY-MM-DD',
     i18n: 'en',
+    rangeConstraint: 'none',
     customI18n: {},
     color: {}
   }
@@ -153,7 +155,18 @@ export default class Calendar extends Component {
       startDate,
       endDate
     } = this.state;
-    if ((!startDate && !endDate) || day < startDate || (startDate && endDate)) {
+    if (this.props.rangeConstraint === 'week') {
+      let startDay = Moment(day).startOf('week')
+      let endDay = Moment(day).endOf('week')
+      this.setState({
+        startDate: startDay,
+        endDate: endDay,
+        startDateText: this._i18n(startDay, 'date'),
+        startWeekdayText: this._i18n(startDay.isoWeekday(), 'weekday'),
+        endDateText: this._i18n(endDay, 'date'),
+        endWeekdayText: this._i18n(endDay.isoWeekday(), 'weekday')
+      });
+    } else if ((!startDate && !endDate) || day < startDate || (startDate && endDate)) {
       this.setState({
         startDate: day,
         endDate: null,


### PR DESCRIPTION
First off, thank you for this nice looking component. I needed a component that allows selecting weeks that correspond to timesheets. This PR adds a `rangeConstraint` prop that currently only supports "week". This enables selecting entire weeks. Could be expanded to address #1 