### PR TITLE
Add total support for I18N and for custom first weekday selection

### DIFF
--- a/Calendar.js
+++ b/Calendar.js
@@ -33,6 +33,7 @@ export default class Calendar extends Component {
     color: {}
   }
   static DEFAULT_I18N_MAP = {
+    'firstWeekday': 7,
     'w': ['Mon', 'Tues', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun'],
     'weekday': ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'],
     'text': {
@@ -55,6 +56,7 @@ export default class Calendar extends Component {
     this._getDateRange = this._getDateRange.bind(this);
     this._onChoose = this._onChoose.bind(this);
     this._resetCalendar = this._resetCalendar.bind(this);
+    this._getFirstWeekday = this._getFirstWeekday.bind(this);
     this.close = this.close.bind(this);
     this.cancel = this.cancel.bind(this);
     this.open = this.open.bind(this);
@@ -143,6 +145,26 @@ export default class Calendar extends Component {
         endWeekdayText: this._i18n(this._getIsoWeekdayForI18n(day), 'weekday')
       });
     }
+  }
+  _getFirstWeekday () {
+    let defaultFirstWeekday = Calendar.DEFAULT_I18N_MAP['firstWeekday'];
+    let firstWeekday = this.props.customI18n['firstWeekday'] || defaultFirstWeekday;
+    return ((firstWeekday <= 7) ? firstWeekday : defaultFirstWeekday);
+  }
+  _getWeeknums () {
+    let firstWeekday = this._getFirstWeekday();
+    if (firstWeekday > 7) {
+      firstWeekday = Calendar.DEFAULT_I18N_MAP['firstWeekday'];;
+    }
+    let days = [];
+    for (let i = 0; i < 7; i++) {
+      days.push(firstWeekday - 1);
+      firstWeekday++;
+      if (firstWeekday > 7) {
+        firstWeekday = 1;
+      }
+    }
+    return days;
   }
   cancel () {
     this.close();
@@ -247,13 +269,14 @@ export default class Calendar extends Component {
             </View>
           </View>
           <View style={styles.week}>
-            {[7, 1, 2, 3, 4, 5, 6].map(item =>
+            {this._getWeeknums().map(item =>
               <Text style={[styles.weekText, subFontColor]}　key={item}>{this._i18n(item, 'w')}</Text>
             )}
           </View>
           <View style={[styles.scroll, {borderColor}]}>
             <MonthList
               today={this._today}
+              firstWeekday={this._getFirstWeekday()}
               minDate={this._minDate}
               maxDate={this._maxDate}
               startDate={this.state.startDate}

--- a/Calendar.js
+++ b/Calendar.js
@@ -21,7 +21,6 @@ const ICON = {
 };
 export default class Calendar extends Component {
   static propTypes = {
-    i18n: PropTypes.string,
     format: PropTypes.string,
     customI18n: PropTypes.object,
     color: PropTypes.object,
@@ -30,47 +29,20 @@ export default class Calendar extends Component {
   }
   static defaultProps = {
     format: 'YYYY-MM-DD',
-    i18n: 'en',
     customI18n: {},
     color: {}
   }
-  static I18N_MAP = {
-    'zh': {
-      'w': ['', '一', '二', '三', '四', '五', '六', '日'],
-      'weekday': ['', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六', '星期日'],
-      'text': {
-        'start': '开 始',
-        'end': '结 束',
-        'date': '日 期',
-        'save': '保 存',
-        'clear': '清除'
-      },
-      'date': 'M月D日'
+  static DEFAULT_I18N_MAP = {
+    'w': ['Mon', 'Tues', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun'],
+    'weekday': ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'],
+    'text': {
+      'start': 'Start',
+      'end': 'End',
+      'date': 'Date',
+      'save': 'Save',
+      'clear': 'Reset'
     },
-    'en': {
-      'w': ['', 'Mon', 'Tues', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun'],
-      'weekday': ['', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'],
-      'text': {
-        'start': 'Start',
-        'end': 'End',
-        'date': 'Date',
-        'save': 'Save',
-        'clear': 'Reset'
-      },
-      'date': 'DD / MM'
-    },
-    'jp': {
-      'w': ['', '月', '火', '水', '木', '金', '土', '日'],
-      'weekday': ['', '月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日', '日曜日'],
-      'text': {
-        'start': 'スタート',
-        'end': 'エンド',
-        'date': '時　間',
-        'save': '確　認',
-        'clear': 'クリア'
-      },
-      'date': 'M月D日'
-    }
+    'date': 'DD / MM'
   }
   constructor (props) {
     super(props);
@@ -95,14 +67,13 @@ export default class Calendar extends Component {
   }
   _i18n (data, type) {
     const {
-      i18n,
       customI18n
     } = this.props;
     if (~['w', 'weekday', 'text'].indexOf(type)) {
-      return (customI18n[type] || {})[data] || Calendar.I18N_MAP[i18n][type][data];
+      return (customI18n[type] || {})[data] || Calendar.DEFAULT_I18N_MAP[type][data];
     }
     if (type === 'date') {
-      return data.format(customI18n[type] || Calendar.I18N_MAP[i18n][type]);
+      return data.format(customI18n[type] || Calendar.DEFAULT_I18N_MAP[type]);
     }
   }
   _resetCalendar () {
@@ -118,11 +89,14 @@ export default class Calendar extends Component {
     this.setState({
       startDate: isStartValid ? start : null,
       startDateText: isStartValid ? this._i18n(start, 'date') : '',
-      startWeekdayText: isStartValid ? this._i18n(start.isoWeekday(), 'weekday') : '',
+      startWeekdayText: isStartValid ? this._i18n(this._getIsoWeekdayForI18n(start), 'weekday') : '',
       endDate: isEndValid ? end: null,
       endDateText: isEndValid ? this._i18n(end, 'date') : '',
-      endWeekdayText: isEndValid ? this._i18n(end.isoWeekday(), 'weekday') : ''
+      endWeekdayText: isEndValid ? this._i18n(this._getIsoWeekdayForI18n(end), 'weekday') : ''
     });
+  }
+  _getIsoWeekdayForI18n (day) {
+    return day.isoWeekday() - 1;
   }
   _getDateRange () {
     const {
@@ -158,7 +132,7 @@ export default class Calendar extends Component {
         startDate: day,
         endDate: null,
         startDateText: this._i18n(day, 'date'),
-        startWeekdayText: this._i18n(day.isoWeekday(), 'weekday'),
+        startWeekdayText: this._i18n(this._getIsoWeekdayForI18n(day), 'weekday'),
         endDateText: '',
         endWeekdayText: '',
       });
@@ -166,7 +140,7 @@ export default class Calendar extends Component {
       this.setState({
         endDate: day,
         endDateText: this._i18n(day, 'date'),
-        endWeekdayText: this._i18n(day.isoWeekday(), 'weekday')
+        endWeekdayText: this._i18n(this._getIsoWeekdayForI18n(day), 'weekday')
       });
     }
   }
@@ -285,7 +259,7 @@ export default class Calendar extends Component {
               startDate={this.state.startDate}
               endDate={this.state.endDate}
               onChoose={this._onChoose}
-              i18n={this.props.i18n}
+              customI18n={this.props.customI18n}
               color={color}
             />
           </View>

--- a/Month/index.js
+++ b/Month/index.js
@@ -20,36 +20,28 @@ export default class Month extends Component {
     this._renderDayRow = this._renderDayRow.bind(this);
     this._getMonthText = this._getMonthText.bind(this);
   }
-  static I18N_MAP = {
-    'zh': [
-      '一月', '二月', '三月', '四月', '五月', '六月',
-      '七月', '八月', '九月', '十月', '十一月', '十二月'
-    ],
-    'jp': [
-      '一月', '二月', '三月', '四月', '五月', '六月',
-      '七月', '八月', '九月', '十月', '十一月', '十二月'
-    ],
-    'en': [
-      'January', 'February', 'March', 'April', 'May', 'June',
-      'July', 'August', 'September', 'October', 'November', 'December'
-    ]
-  }
+  static DEFAULT_I18N_MONTH_NAMES = [
+    'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December'
+  ]
+
   _getMonthText () {
     const {
       month,
       today,
-      i18n
+      customI18n
     } = this.props;
     let y = month.year();
     let m = month.month();
     let year = today.year();
+    let monthNames = Month.DEFAULT_I18N_MONTH_NAMES;
+    if (customI18n && customI18n['m']) {
+      monthNames = customI18n['m'];
+    }
     if (year === y) {
-      return Month.I18N_MAP[i18n][m];
+      return monthNames[m] || Month.DEFAULT_I18N_MONTH_NAMES[m];
     } else {
-      if (i18n === 'en') {
-        return `${Month.I18N_MAP[i18n][m]}, ${y}`;
-      }
-      return month.format('YYYY年M月');
+      return `${monthNames[m] || Month.DEFAULT_I18N_MONTH_NAMES[m]}, ${y}`;
     }
   }
   _getDayList (date) {

--- a/Month/index.js
+++ b/Month/index.js
@@ -48,10 +48,17 @@ export default class Month extends Component {
     let dayList;
     let month = date.month();
     let weekday = date.isoWeekday();
-    if (weekday === 7) {
+    let firstWeekday = this.props.firstWeekday;
+    if (weekday === firstWeekday) {
       dayList = [];
     } else {
-      dayList = new Array(weekday).fill({
+      let arrayLength;
+      if (weekday > firstWeekday) {
+        arrayLength = Math.abs(weekday - firstWeekday);
+      } else {
+        arrayLength = 7 - Math.abs(weekday - firstWeekday);
+      }
+      dayList = new Array(arrayLength).fill({
         empty: date.clone().subtract(1, 'h')
       });
     }
@@ -63,12 +70,12 @@ export default class Month extends Component {
     }
     date.subtract(1, 'days');
     weekday = date.isoWeekday();
-    if (weekday === 7) {
+    if (weekday === firstWeekday) {
       return dayList.concat(new Array(6).fill({
         empty: date.clone().hour(1)
       }));
     }
-    return dayList.concat(new Array(Math.abs(weekday - 6)).fill({
+    return dayList.concat(new Array(Math.abs((weekday - firstWeekday) - 6)).fill({
       empty: date.clone().hour(1)
     }));
   }

--- a/index.ios.js
+++ b/index.ios.js
@@ -40,6 +40,7 @@ export default class calendar extends Component {
   render() {
     // It's an optional property, I use this to show the structure of customI18n object.
     let customI18n = {
+      'firstWeekday': 1,
       'w': ['Lun', 'Mar', 'Mie', 'Jue', 'Vie', 'Sab', 'Dom'],
       'm': ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
       'weekday': ['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado', 'Domingo'],

--- a/index.ios.js
+++ b/index.ios.js
@@ -40,14 +40,15 @@ export default class calendar extends Component {
   render() {
     // It's an optional property, I use this to show the structure of customI18n object.
     let customI18n = {
-      'w': ['', 'Mon', 'Tues', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun'],
-      'weekday': ['', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'],
+      'w': ['Lun', 'Mar', 'Mie', 'Jue', 'Vie', 'Sab', 'Dom'],
+      'm': ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
+      'weekday': ['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado', 'Domingo'],
       'text': {
-        'start': 'Check in',
-        'end': 'Check out',
-        'date': 'Date',
-        'save': 'Confirm',
-        'clear': 'Reset'
+        'start': 'Entrada',
+        'end': 'Salida',
+        'date': 'Fecha',
+        'save': 'Confirmar',
+        'clear': 'Limpiar'
       },
       'date': 'DD / MM'  // date format
     };
@@ -74,9 +75,9 @@ export default class calendar extends Component {
           <Text style={styles.font}>{text}</Text>
         </View>
         <Calendar
-          i18n="en"
           color={color}
           ref={(calendar) => {this.calendar = calendar;}}
+          customI18n={customI18n}
           format="YYYYMMDD"
           minDate="20170510"
           maxDate="20180412"


### PR DESCRIPTION
Hi,
At first time, congratulations for this amazing component. I tried to make a similar component but you made it better than me xD

I did two commits to improve your calendar component:
 - Add total support for I18N, including month names. Set "en" as default language. In case you don't add the customI18n object, or any property is not included, a default english value will be used.
 - Allow to select the first weekday for calendar (month days and week names). For example in Spain the first weekday is Monday. With these changes you can select any day as first weekday.

I hope you like these two commits.

Regards