### PR TITLE
integrate FlatList instead of ListView

### DIFF
--- a/MonthList.js
+++ b/MonthList.js
@@ -6,7 +6,7 @@ import React, {PropTypes, Component} from 'react';
 import {
   View,
   Text,
-  ListView,
+  FlatList,
   Dimensions
 } from 'react-native';
 import Moment from 'moment';
@@ -16,14 +16,9 @@ const {width} = Dimensions.get('window');
 export default class MonthList extends Component {
   constructor (props) {
     super(props);
-    this.ds = new ListView.DataSource({
-      rowHasChanged: (r1, r2) => {
-        return r2.shouldUpdate;
-      }
-    });
     this.monthList = [];
     this.state = {
-      dataSource: this.ds.cloneWithRows(this._getMonthList())
+      dataSource: this._getMonthList()
     };
     this._renderMonth = this._renderMonth.bind(this);
     this._shouldUpdate = this._shouldUpdate.bind(this);
@@ -40,14 +35,14 @@ export default class MonthList extends Component {
     }, false);
     if (isDateUpdated) {
       this.setState({
-        dataSource:
-          this.state.dataSource.cloneWithRows(this._getMonthList(nextProps))
+        dataSource: this._getMonthList(nextProps)
       });
     }
   }
   _renderMonth (month) {
     return (
       <Month
+        key={Math.random()}
         month={month.date || {}}
         {...this.props}
       />
@@ -126,11 +121,11 @@ export default class MonthList extends Component {
   }
   render () {
     return (
-      <ListView
+      <FlatList
         ref={(list) => {this.list = list;}}
         style={styles.scrollArea}
-        dataSource={this.state.dataSource}
-        renderRow={this._renderMonth}
+        data={this.state.dataSource}
+        renderItem={this._renderMonth}
         pageSize={2}
         initialListSize={2}
         showsVerticalScrollIndicator={false}


### PR DESCRIPTION
Because of React Native 60+ deprecated ListView component we have to use other components. One of them is FlatList. Read more here https://facebook.github.io/react-native/docs/listview.html